### PR TITLE
feat: added sample serializer with audio_url generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem "dotenv-rails"
 gem "cloudinary"
 gem "jwt"
 
+gem 'active_model_serializers'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,11 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_model_serializers (0.10.15)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.2.2.1)
       activesupport (= 7.2.2.1)
       globalid (>= 0.3.6)
@@ -82,6 +87,8 @@ GEM
     brakeman (7.0.2)
       racc
     builder (3.3.0)
+    case_transform (0.2)
+      activesupport
     cloudinary (2.3.0)
       faraday (>= 2.0.1, < 3.0.0)
       faraday-follow_redirects (~> 0.3.0)
@@ -121,6 +128,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.12.2)
+    jsonapi-renderer (0.2.2)
     jwt (2.10.1)
       base64
     language_server-protocol (3.17.0.5)
@@ -289,6 +297,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  active_model_serializers
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman

--- a/app/serializers/sample_serializer.rb
+++ b/app/serializers/sample_serializer.rb
@@ -1,0 +1,13 @@
+class SampleSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :name, :audio_url
+
+  def audio_url
+    if object.audio.attached?
+      url_for(object.audio)
+    else
+      nil
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,8 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  Rails.application.routes.default_url_options[:host] = "localhost:3000"
+
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :cloudinary
 


### PR DESCRIPTION
- generated sample serializer to format API responses
- defined audio_url method to return full url for attached audio
- added, :name, and :audio_url to serialized attributes
- configured default_url_options[:host] for development
